### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/deps/dep-9n5d48b0v02l4cgfnpxhymcp43d1mpla-source/README.md
+++ b/deps/dep-9n5d48b0v02l4cgfnpxhymcp43d1mpla-source/README.md
@@ -28,8 +28,8 @@
 * [Discourse Forum](https://discourse.nixos.org/)
 * [Matrix Chat](https://matrix.to/#/#community:nixos.org)
 * [NixOS Weekly](https://weekly.nixos.org/)
-* [Community-maintained wiki](https://nixos.wiki/)
-* [Community-maintained list of ways to get in touch](https://nixos.wiki/wiki/Get_In_Touch#Chat) (Discord, Telegram, IRC, etc.)
+* [Community-maintained wiki](https://wiki.nixos.org/)
+* [Community-maintained list of ways to get in touch](https://wiki.nixos.org/wiki/Get_In_Touch#Chat) (Discord, Telegram, IRC, etc.)
 
 # Other Project Repositories
 

--- a/deps/dep-9n5d48b0v02l4cgfnpxhymcp43d1mpla-source/doc/languages-frameworks/javascript.section.md
+++ b/deps/dep-9n5d48b0v02l4cgfnpxhymcp43d1mpla-source/doc/languages-frameworks/javascript.section.md
@@ -256,7 +256,7 @@ mkYarnPackage rec {
 
 ## Outside of nixpkgs {#javascript-outside-nixpkgs}
 
-There are some other options available that can't be used inside nixpkgs. Those other options are written in Nix. Importing them in nixpkgs will require moving the source code into nixpkgs. Using [Import From Derivation](https://nixos.wiki/wiki/Import_From_Derivation) is not allowed in Hydra at present. If you are packaging something outside nixpkgs, those can be considered
+There are some other options available that can't be used inside nixpkgs. Those other options are written in Nix. Importing them in nixpkgs will require moving the source code into nixpkgs. Using [Import From Derivation](https://wiki.nixos.org/wiki/Import_From_Derivation) is not allowed in Hydra at present. If you are packaging something outside nixpkgs, those can be considered
 
 ### npmlock2nix {#javascript-npmlock2nix}
 

--- a/deps/dep-9n5d48b0v02l4cgfnpxhymcp43d1mpla-source/nixos/doc/manual/from_md/installation/obtaining.chapter.xml
+++ b/deps/dep-9n5d48b0v02l4cgfnpxhymcp43d1mpla-source/nixos/doc/manual/from_md/installation/obtaining.chapter.xml
@@ -10,7 +10,7 @@
     <xref linkend="sec-booting-from-usb" /> describes the preferred
     method to prepare a USB stick. A number of alternative methods are
     presented in the
-    <link xlink:href="https://nixos.wiki/wiki/NixOS_Installation_Guide#Making_the_installation_media">NixOS
+    <link xlink:href="https://wiki.nixos.org/wiki/NixOS_Installation_Guide#Making_the_installation_media">NixOS
     Wiki</link>.
   </para>
   <para>

--- a/deps/dep-9n5d48b0v02l4cgfnpxhymcp43d1mpla-source/nixos/doc/manual/from_md/release-notes/rl-1909.section.xml
+++ b/deps/dep-9n5d48b0v02l4cgfnpxhymcp43d1mpla-source/nixos/doc/manual/from_md/release-notes/rl-1909.section.xml
@@ -858,7 +858,7 @@
           be open for it to work, so something like
           <literal>networking.firewall.allowedTCPPorts = [ 8010 ];</literal>
           may be required in your configuration. Also consider enabling
-          <link xlink:href="https://nixos.wiki/wiki/Accelerated_Video_Playback">
+          <link xlink:href="https://wiki.nixos.org/wiki/Accelerated_Video_Playback">
           Accelerated Video Playback</link> for better transcoding
           performance.
         </para>

--- a/deps/dep-9n5d48b0v02l4cgfnpxhymcp43d1mpla-source/nixos/doc/manual/installation/obtaining.chapter.md
+++ b/deps/dep-9n5d48b0v02l4cgfnpxhymcp43d1mpla-source/nixos/doc/manual/installation/obtaining.chapter.md
@@ -7,7 +7,7 @@ CD, burning the image to CD and booting from that is probably the
 easiest option. Most people will need to prepare a USB stick to boot
 from. [](#sec-booting-from-usb) describes the preferred method to
 prepare a USB stick. A number of alternative methods are presented in
-the [NixOS Wiki](https://nixos.wiki/wiki/NixOS_Installation_Guide#Making_the_installation_media).
+the [NixOS Wiki](https://wiki.nixos.org/wiki/NixOS_Installation_Guide#Making_the_installation_media).
 
 As an alternative to installing NixOS yourself, you can get a running
 NixOS system through several other means:

--- a/deps/dep-9n5d48b0v02l4cgfnpxhymcp43d1mpla-source/nixos/doc/manual/release-notes/rl-1909.section.md
+++ b/deps/dep-9n5d48b0v02l4cgfnpxhymcp43d1mpla-source/nixos/doc/manual/release-notes/rl-1909.section.md
@@ -230,7 +230,7 @@ When upgrading from a previous release, please be aware of the following incompa
 
 - The `documentation` module gained an option named `documentation.nixos.includeAllModules` which makes the generated configuration.nix 5 manual page include all options from all NixOS modules included in a given `configuration.nix` configuration file. Currently, it is set to `false` by default as enabling it frequently prevents evaluation. But the plan is to eventually have it set to `true` by default. Please set it to `true` now in your `configuration.nix` and fix all the bugs it uncovers.
 
-- The `vlc` package gained support for Chromecast streaming, enabled by default. TCP port 8010 must be open for it to work, so something like `networking.firewall.allowedTCPPorts = [ 8010 ];` may be required in your configuration. Also consider enabling [ Accelerated Video Playback](https://nixos.wiki/wiki/Accelerated_Video_Playback) for better transcoding performance.
+- The `vlc` package gained support for Chromecast streaming, enabled by default. TCP port 8010 must be open for it to work, so something like `networking.firewall.allowedTCPPorts = [ 8010 ];` may be required in your configuration. Also consider enabling [ Accelerated Video Playback](https://wiki.nixos.org/wiki/Accelerated_Video_Playback) for better transcoding performance.
 
 - The following changes apply if the `stateVersion` is changed to 19.09 or higher. For `stateVersion = "19.03"` or lower the old behavior is preserved.
 

--- a/deps/dep-9n5d48b0v02l4cgfnpxhymcp43d1mpla-source/pkgs/development/tools/build-managers/ekam/default.nix
+++ b/deps/dep-9n5d48b0v02l4cgfnpxhymcp43d1mpla-source/pkgs/development/tools/build-managers/ekam/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
   # of the nix store -- but ekam builds capnp locally and links against it,
   # so that causes the build to fail. So, we turn this off.
   #
-  # See: https://nixos.wiki/wiki/Development_environment_with_nix-shell#Troubleshooting
+  # See: https://wiki.nixos.org/wiki/Development_environment_with_nix-shell#Troubleshooting
   preBuild = ''
     unset NIX_ENFORCE_PURITY
   '';

--- a/deps/dep-9n5d48b0v02l4cgfnpxhymcp43d1mpla-source/pkgs/tools/misc/polar/default.nix
+++ b/deps/dep-9n5d48b0v02l4cgfnpxhymcp43d1mpla-source/pkgs/tools/misc/polar/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   '';
   buildInputs = [ gems ruby ];
 
-  # See: https://nixos.wiki/wiki/Packaging/Ruby
+  # See: https://wiki.nixos.org/wiki/Packaging/Ruby
   #
   # Put library content under lib/polar and the raw scripts under share/polar.
   # Then, wrap the scripts so that they use the correct ruby environment and put

--- a/deps/dep-blrdcq96cni538qspqibgr0yhrqkxrfc-source/README.md
+++ b/deps/dep-blrdcq96cni538qspqibgr0yhrqkxrfc-source/README.md
@@ -112,7 +112,7 @@ License
 This project is licensed under the terms of the [MIT license](LICENSE).
 
 [#home-manager]: https://webchat.oftc.net/?channels=home-manager
-[Nix Flakes]: https://nixos.wiki/wiki/Flakes
+[Nix Flakes]: https://wiki.nixos.org/wiki/Flakes
 [NixOS]: https://nixos.org/
 [Nix]: https://nixos.org/explore.html
 [Nixpkgs]: https://github.com/NixOS/nixpkgs

--- a/deps/dep-blrdcq96cni538qspqibgr0yhrqkxrfc-source/docs/manual/installation.md
+++ b/deps/dep-blrdcq96cni538qspqibgr0yhrqkxrfc-source/docs/manual/installation.md
@@ -24,7 +24,7 @@ Home Manager can be used in three primary ways:
 :::{.note}
 In this chapter we describe how to install Home Manager in the standard
 way using channels. If you prefer to use [Nix
-Flakes](https://nixos.wiki/wiki/Flakes) then please see the instructions
+Flakes](https://wiki.nixos.org/wiki/Flakes) then please see the instructions
 in [nix flakes](#ch-nix-flakes).
 :::
 

--- a/deps/dep-blrdcq96cni538qspqibgr0yhrqkxrfc-source/docs/manual/nix-flakes.md
+++ b/deps/dep-blrdcq96cni538qspqibgr0yhrqkxrfc-source/docs/manual/nix-flakes.md
@@ -1,7 +1,7 @@
 # Nix Flakes {#ch-nix-flakes}
 
 Home Manager is compatible with [Nix
-Flakes](https://nixos.wiki/wiki/Flakes). But please be aware that this
+Flakes](https://wiki.nixos.org/wiki/Flakes). But please be aware that this
 support is still experimental and may change in backwards
 incompatible ways.
 

--- a/deps/dep-blrdcq96cni538qspqibgr0yhrqkxrfc-source/docs/manual/nix-flakes/standalone.md
+++ b/deps/dep-blrdcq96cni538qspqibgr0yhrqkxrfc-source/docs/manual/nix-flakes/standalone.md
@@ -58,5 +58,5 @@ If you only want to update a single flake input, then the command
 You can also pass flake-related options such as `--recreate-lock-file`
 or `--update-input <input>` to `home-manager` when building or
 switching, and these options will be forwarded to `nix build`. See the
-[NixOS Wiki page](https://nixos.wiki/wiki/Flakes) for details.
+[NixOS Wiki page](https://wiki.nixos.org/wiki/Flakes) for details.
 :::

--- a/deps/dep-blrdcq96cni538qspqibgr0yhrqkxrfc-source/modules/programs/firefox.nix
+++ b/deps/dep-blrdcq96cni538qspqibgr0yhrqkxrfc-source/modules/programs/firefox.nix
@@ -416,7 +416,7 @@ in {
                       {
                         name = "wiki";
                         tags = [ "wiki" "nix" ];
-                        url = "https://nixos.wiki/";
+                        url = "https://wiki.nixos.org/";
                       }
                     ];
                   }
@@ -502,8 +502,8 @@ in {
                     };
 
                     "NixOS Wiki" = {
-                      urls = [{ template = "https://nixos.wiki/index.php?search={searchTerms}"; }];
-                      iconUpdateURL = "https://nixos.wiki/favicon.png";
+                      urls = [{ template = "https://wiki.nixos.org/index.php?search={searchTerms}"; }];
+                      iconUpdateURL = "https://wiki.nixos.org/favicon.png";
                       updateInterval = 24 * 60 * 60 * 1000; # every day
                       definedAliases = [ "@nw" ];
                     };

--- a/deps/dep-blrdcq96cni538qspqibgr0yhrqkxrfc-source/modules/programs/qutebrowser.nix
+++ b/deps/dep-blrdcq96cni538qspqibgr0yhrqkxrfc-source/modules/programs/qutebrowser.nix
@@ -81,7 +81,7 @@ in {
         {
           w = "https://en.wikipedia.org/wiki/Special:Search?search={}&go=Go&ns0=1";
           aw = "https://wiki.archlinux.org/?search={}";
-          nw = "https://nixos.wiki/index.php?search={}";
+          nw = "https://wiki.nixos.org/index.php?search={}";
           g = "https://www.google.com/search?hl=en&q={}";
         }
       '';

--- a/deps/dep-blrdcq96cni538qspqibgr0yhrqkxrfc-source/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
+++ b/deps/dep-blrdcq96cni538qspqibgr0yhrqkxrfc-source/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
@@ -8,18 +8,18 @@
 <DL><p>
   <DT><H3 ADD_DATE="1" LAST_MODIFIED="1" PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Toolbar</H3>
   <DL><p>
-    <DT><A HREF="https://nixos.wiki/wiki/Home_Manager" ADD_DATE="1" LAST_MODIFIED="1">Home Manager</A>
+    <DT><A HREF="https://wiki.nixos.org/wiki/Home_Manager" ADD_DATE="1" LAST_MODIFIED="1">Home Manager</A>
   </DL><p>
   <DT><A HREF="https://en.wikipedia.org/wiki/Special:Search?search=%s&amp;go=Go" ADD_DATE="1" LAST_MODIFIED="1" SHORTCUTURL="wiki" TAGS="wiki">wikipedia</A>
   <DT><A HREF="https://www.kernel.org" ADD_DATE="1" LAST_MODIFIED="1">kernel.org</A>
   <DT><H3 ADD_DATE="1" LAST_MODIFIED="1">Nix sites</H3>
   <DL><p>
     <DT><A HREF="https://nixos.org/" ADD_DATE="1" LAST_MODIFIED="1">homepage</A>
-    <DT><A HREF="https://nixos.wiki/" ADD_DATE="1" LAST_MODIFIED="1" TAGS="wiki,nix">wiki</A>
+    <DT><A HREF="https://wiki.nixos.org/" ADD_DATE="1" LAST_MODIFIED="1" TAGS="wiki,nix">wiki</A>
     <DT><H3 ADD_DATE="1" LAST_MODIFIED="1">Nix sites</H3>
     <DL><p>
       <DT><A HREF="https://nixos.org/" ADD_DATE="1" LAST_MODIFIED="1">homepage</A>
-      <DT><A HREF="https://nixos.wiki/" ADD_DATE="1" LAST_MODIFIED="1">wiki</A>
+      <DT><A HREF="https://wiki.nixos.org/" ADD_DATE="1" LAST_MODIFIED="1">wiki</A>
     </DL><p>
   </DL><p>
 </DL>

--- a/deps/dep-blrdcq96cni538qspqibgr0yhrqkxrfc-source/tests/modules/programs/firefox/profile-settings-expected-search.json
+++ b/deps/dep-blrdcq96cni538qspqibgr0yhrqkxrfc-source/tests/modules/programs/firefox/profile-settings-expected-search.json
@@ -31,8 +31,8 @@
       "_definedAliases": [
         "@nw"
       ],
-      "_iconURL": "https://nixos.wiki/favicon.png",
-      "_iconUpdateURL": "https://nixos.wiki/favicon.png",
+      "_iconURL": "https://wiki.nixos.org/favicon.png",
+      "_iconUpdateURL": "https://wiki.nixos.org/favicon.png",
       "_isAppProvided": false,
       "_loadPath": "[home-manager]/programs.firefox.profiles.search.search.engines.\"NixOS Wiki\"",
       "_metaData": {
@@ -42,7 +42,7 @@
       "_updateInterval": 86400000,
       "_urls": [
         {
-          "template": "https://nixos.wiki/index.php?search={searchTerms}"
+          "template": "https://wiki.nixos.org/index.php?search={searchTerms}"
         }
       ]
     },

--- a/deps/dep-blrdcq96cni538qspqibgr0yhrqkxrfc-source/tests/modules/programs/firefox/profile-settings.nix
+++ b/deps/dep-blrdcq96cni538qspqibgr0yhrqkxrfc-source/tests/modules/programs/firefox/profile-settings.nix
@@ -27,7 +27,7 @@
             toolbar = true;
             bookmarks = [{
               name = "Home Manager";
-              url = "https://nixos.wiki/wiki/Home_Manager";
+              url = "https://wiki.nixos.org/wiki/Home_Manager";
             }];
           }
           {
@@ -51,7 +51,7 @@
               {
                 name = "wiki";
                 tags = [ "wiki" "nix" ];
-                url = "https://nixos.wiki/";
+                url = "https://wiki.nixos.org/";
               }
               {
                 name = "Nix sites";
@@ -62,7 +62,7 @@
                   }
                   {
                     name = "wiki";
-                    url = "https://nixos.wiki/";
+                    url = "https://wiki.nixos.org/";
                   }
                 ];
               }
@@ -102,9 +102,9 @@
 
             "NixOS Wiki" = {
               urls = [{
-                template = "https://nixos.wiki/index.php?search={searchTerms}";
+                template = "https://wiki.nixos.org/index.php?search={searchTerms}";
               }];
-              iconUpdateURL = "https://nixos.wiki/favicon.png";
+              iconUpdateURL = "https://wiki.nixos.org/favicon.png";
               updateInterval = 24 * 60 * 60 * 1000;
               definedAliases = [ "@nw" ];
             };

--- a/deps/dep-pc4i9q5lm8cyb74hgcav4ms0wbfbk66m-source/README.md
+++ b/deps/dep-pc4i9q5lm8cyb74hgcav4ms0wbfbk66m-source/README.md
@@ -7,7 +7,7 @@
 A compatible but better replacement for rust overlay of [nixpkgs-mozilla].
 
 Hashes of toolchain components are pre-fetched in tree, so the evaluation is *pure* and
-no need to have network access. It also works well with [Nix Flakes](https://nixos.wiki/wiki/Flakes).
+no need to have network access. It also works well with [Nix Flakes](https://wiki.nixos.org/wiki/Flakes).
 
 - The toolchain hashes are auto-updated daily using GitHub Actions.
 - Current oldest supported version is stable 1.29.0 and beta/nightly 2018-09-13

--- a/deps/dep-pc4i9q5lm8cyb74hgcav4ms0wbfbk66m-source/docs/cross_compilation.md
+++ b/deps/dep-pc4i9q5lm8cyb74hgcav4ms0wbfbk66m-source/docs/cross_compilation.md
@@ -57,4 +57,4 @@ mkShell {
 ```
 
 For more details about these different kinds of dependencies,
-see also [Nix Wiki - Cross Compiling](https://nixos.wiki/wiki/Cross_Compiling#How_to_specify_dependencies).
+see also [Nix Wiki - Cross Compiling](https://wiki.nixos.org/wiki/Cross_Compiling#How_to_specify_dependencies).

--- a/deps/dep-ra73hcmlxam2knmrznya595fwnrk6ssc-source/README.md
+++ b/deps/dep-ra73hcmlxam2knmrznya595fwnrk6ssc-source/README.md
@@ -112,7 +112,7 @@ License
 This project is licensed under the terms of the [MIT license](LICENSE).
 
 [#home-manager]: https://webchat.oftc.net/?channels=home-manager
-[Nix Flakes]: https://nixos.wiki/wiki/Flakes
+[Nix Flakes]: https://wiki.nixos.org/wiki/Flakes
 [NixOS]: https://nixos.org/
 [Nix]: https://nixos.org/explore.html
 [Nixpkgs]: https://github.com/NixOS/nixpkgs

--- a/deps/dep-ra73hcmlxam2knmrznya595fwnrk6ssc-source/docs/manual/installation.md
+++ b/deps/dep-ra73hcmlxam2knmrznya595fwnrk6ssc-source/docs/manual/installation.md
@@ -24,7 +24,7 @@ Home Manager can be used in three primary ways:
 :::{.note}
 In this chapter we describe how to install Home Manager in the standard
 way using channels. If you prefer to use [Nix
-Flakes](https://nixos.wiki/wiki/Flakes) then please see the instructions
+Flakes](https://wiki.nixos.org/wiki/Flakes) then please see the instructions
 in [nix flakes](#ch-nix-flakes).
 :::
 

--- a/deps/dep-ra73hcmlxam2knmrznya595fwnrk6ssc-source/docs/manual/nix-flakes.md
+++ b/deps/dep-ra73hcmlxam2knmrznya595fwnrk6ssc-source/docs/manual/nix-flakes.md
@@ -1,7 +1,7 @@
 # Nix Flakes {#ch-nix-flakes}
 
 Home Manager is compatible with [Nix
-Flakes](https://nixos.wiki/wiki/Flakes). But please be aware that this
+Flakes](https://wiki.nixos.org/wiki/Flakes). But please be aware that this
 support is still experimental and may change in backwards
 incompatible ways.
 

--- a/deps/dep-ra73hcmlxam2knmrznya595fwnrk6ssc-source/docs/manual/nix-flakes/standalone.md
+++ b/deps/dep-ra73hcmlxam2knmrznya595fwnrk6ssc-source/docs/manual/nix-flakes/standalone.md
@@ -58,5 +58,5 @@ If you only want to update a single flake input, then the command
 You can also pass flake-related options such as `--recreate-lock-file`
 or `--update-input <input>` to `home-manager` when building or
 switching, and these options will be forwarded to `nix build`. See the
-[NixOS Wiki page](https://nixos.wiki/wiki/Flakes) for details.
+[NixOS Wiki page](https://wiki.nixos.org/wiki/Flakes) for details.
 :::

--- a/deps/dep-ra73hcmlxam2knmrznya595fwnrk6ssc-source/modules/programs/firefox.nix
+++ b/deps/dep-ra73hcmlxam2knmrznya595fwnrk6ssc-source/modules/programs/firefox.nix
@@ -411,7 +411,7 @@ in {
                       {
                         name = "wiki";
                         tags = [ "wiki" "nix" ];
-                        url = "https://nixos.wiki/";
+                        url = "https://wiki.nixos.org/";
                       }
                     ];
                   }
@@ -497,8 +497,8 @@ in {
                     };
 
                     "NixOS Wiki" = {
-                      urls = [{ template = "https://nixos.wiki/index.php?search={searchTerms}"; }];
-                      iconUpdateURL = "https://nixos.wiki/favicon.png";
+                      urls = [{ template = "https://wiki.nixos.org/index.php?search={searchTerms}"; }];
+                      iconUpdateURL = "https://wiki.nixos.org/favicon.png";
                       updateInterval = 24 * 60 * 60 * 1000; # every day
                       definedAliases = [ "@nw" ];
                     };

--- a/deps/dep-ra73hcmlxam2knmrznya595fwnrk6ssc-source/modules/programs/qutebrowser.nix
+++ b/deps/dep-ra73hcmlxam2knmrznya595fwnrk6ssc-source/modules/programs/qutebrowser.nix
@@ -81,7 +81,7 @@ in {
         {
           w = "https://en.wikipedia.org/wiki/Special:Search?search={}&go=Go&ns0=1";
           aw = "https://wiki.archlinux.org/?search={}";
-          nw = "https://nixos.wiki/index.php?search={}";
+          nw = "https://wiki.nixos.org/index.php?search={}";
           g = "https://www.google.com/search?hl=en&q={}";
         }
       '';

--- a/deps/dep-ra73hcmlxam2knmrznya595fwnrk6ssc-source/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
+++ b/deps/dep-ra73hcmlxam2knmrznya595fwnrk6ssc-source/tests/modules/programs/firefox/profile-settings-expected-bookmarks.html
@@ -8,18 +8,18 @@
 <DL><p>
   <DT><H3 PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Toolbar</H3>
   <DL><p>
-    <DT><A HREF="https://nixos.wiki/wiki/Home_Manager" ADD_DATE="1" LAST_MODIFIED="1">Home Manager</A>
+    <DT><A HREF="https://wiki.nixos.org/wiki/Home_Manager" ADD_DATE="1" LAST_MODIFIED="1">Home Manager</A>
   </p></DL>
   <DT><A HREF="https://en.wikipedia.org/wiki/Special:Search?search=%s&amp;go=Go" ADD_DATE="1" LAST_MODIFIED="1" SHORTCUTURL="wiki" TAGS="wiki">wikipedia</A>
   <DT><A HREF="https://www.kernel.org" ADD_DATE="1" LAST_MODIFIED="1">kernel.org</A>
   <DT><H3>Nix sites</H3>
   <DL><p>
     <DT><A HREF="https://nixos.org/" ADD_DATE="1" LAST_MODIFIED="1">homepage</A>
-    <DT><A HREF="https://nixos.wiki/" ADD_DATE="1" LAST_MODIFIED="1" TAGS="wiki,nix">wiki</A>
+    <DT><A HREF="https://wiki.nixos.org/" ADD_DATE="1" LAST_MODIFIED="1" TAGS="wiki,nix">wiki</A>
     <DT><H3>Nix sites</H3>
     <DL><p>
       <DT><A HREF="https://nixos.org/" ADD_DATE="1" LAST_MODIFIED="1">homepage</A>
-      <DT><A HREF="https://nixos.wiki/" ADD_DATE="1" LAST_MODIFIED="1">wiki</A>
+      <DT><A HREF="https://wiki.nixos.org/" ADD_DATE="1" LAST_MODIFIED="1">wiki</A>
     </p></DL>
   </p></DL>
 </p></DL>

--- a/deps/dep-ra73hcmlxam2knmrznya595fwnrk6ssc-source/tests/modules/programs/firefox/profile-settings-expected-search.json
+++ b/deps/dep-ra73hcmlxam2knmrznya595fwnrk6ssc-source/tests/modules/programs/firefox/profile-settings-expected-search.json
@@ -31,8 +31,8 @@
       "_definedAliases": [
         "@nw"
       ],
-      "_iconURL": "https://nixos.wiki/favicon.png",
-      "_iconUpdateURL": "https://nixos.wiki/favicon.png",
+      "_iconURL": "https://wiki.nixos.org/favicon.png",
+      "_iconUpdateURL": "https://wiki.nixos.org/favicon.png",
       "_isAppProvided": false,
       "_loadPath": "[home-manager]/programs.firefox.profiles.search.search.engines.\"NixOS Wiki\"",
       "_metaData": {
@@ -42,7 +42,7 @@
       "_updateInterval": 86400000,
       "_urls": [
         {
-          "template": "https://nixos.wiki/index.php?search={searchTerms}"
+          "template": "https://wiki.nixos.org/index.php?search={searchTerms}"
         }
       ]
     },

--- a/deps/dep-ra73hcmlxam2knmrznya595fwnrk6ssc-source/tests/modules/programs/firefox/profile-settings.nix
+++ b/deps/dep-ra73hcmlxam2knmrznya595fwnrk6ssc-source/tests/modules/programs/firefox/profile-settings.nix
@@ -27,7 +27,7 @@
             toolbar = true;
             bookmarks = [{
               name = "Home Manager";
-              url = "https://nixos.wiki/wiki/Home_Manager";
+              url = "https://wiki.nixos.org/wiki/Home_Manager";
             }];
           }
           {
@@ -51,7 +51,7 @@
               {
                 name = "wiki";
                 tags = [ "wiki" "nix" ];
-                url = "https://nixos.wiki/";
+                url = "https://wiki.nixos.org/";
               }
               {
                 name = "Nix sites";
@@ -62,7 +62,7 @@
                   }
                   {
                     name = "wiki";
-                    url = "https://nixos.wiki/";
+                    url = "https://wiki.nixos.org/";
                   }
                 ];
               }
@@ -102,9 +102,9 @@
 
             "NixOS Wiki" = {
               urls = [{
-                template = "https://nixos.wiki/index.php?search={searchTerms}";
+                template = "https://wiki.nixos.org/index.php?search={searchTerms}";
               }];
-              iconUpdateURL = "https://nixos.wiki/favicon.png";
+              iconUpdateURL = "https://wiki.nixos.org/favicon.png";
               updateInterval = 24 * 60 * 60 * 1000;
               definedAliases = [ "@nw" ];
             };

--- a/deps/dep-rksi78f7vq2xrfghg6jfg1r5dsa8lbv7-source/README.md
+++ b/deps/dep-rksi78f7vq2xrfghg6jfg1r5dsa8lbv7-source/README.md
@@ -28,8 +28,8 @@
 * [Discourse Forum](https://discourse.nixos.org/)
 * [Matrix Chat](https://matrix.to/#/#community:nixos.org)
 * [NixOS Weekly](https://weekly.nixos.org/)
-* [Community-maintained wiki](https://nixos.wiki/)
-* [Community-maintained list of ways to get in touch](https://nixos.wiki/wiki/Get_In_Touch#Chat) (Discord, Telegram, IRC, etc.)
+* [Community-maintained wiki](https://wiki.nixos.org/)
+* [Community-maintained list of ways to get in touch](https://wiki.nixos.org/wiki/Get_In_Touch#Chat) (Discord, Telegram, IRC, etc.)
 
 # Other Project Repositories
 

--- a/deps/dep-rksi78f7vq2xrfghg6jfg1r5dsa8lbv7-source/doc/languages-frameworks/javascript.section.md
+++ b/deps/dep-rksi78f7vq2xrfghg6jfg1r5dsa8lbv7-source/doc/languages-frameworks/javascript.section.md
@@ -333,7 +333,7 @@ mkYarnPackage rec {
 
 ## Outside of nixpkgs {#javascript-outside-nixpkgs}
 
-There are some other options available that can't be used inside nixpkgs. Those other options are written in Nix. Importing them in nixpkgs will require moving the source code into nixpkgs. Using [Import From Derivation](https://nixos.wiki/wiki/Import_From_Derivation) is not allowed in Hydra at present. If you are packaging something outside nixpkgs, those can be considered
+There are some other options available that can't be used inside nixpkgs. Those other options are written in Nix. Importing them in nixpkgs will require moving the source code into nixpkgs. Using [Import From Derivation](https://wiki.nixos.org/wiki/Import_From_Derivation) is not allowed in Hydra at present. If you are packaging something outside nixpkgs, those can be considered
 
 ### npmlock2nix {#javascript-npmlock2nix}
 

--- a/deps/dep-rksi78f7vq2xrfghg6jfg1r5dsa8lbv7-source/nixos/doc/manual/from_md/release-notes/rl-1909.section.xml
+++ b/deps/dep-rksi78f7vq2xrfghg6jfg1r5dsa8lbv7-source/nixos/doc/manual/from_md/release-notes/rl-1909.section.xml
@@ -858,7 +858,7 @@
           be open for it to work, so something like
           <literal>networking.firewall.allowedTCPPorts = [ 8010 ];</literal>
           may be required in your configuration. Also consider enabling
-          <link xlink:href="https://nixos.wiki/wiki/Accelerated_Video_Playback">
+          <link xlink:href="https://wiki.nixos.org/wiki/Accelerated_Video_Playback">
           Accelerated Video Playback</link> for better transcoding
           performance.
         </para>

--- a/deps/dep-rksi78f7vq2xrfghg6jfg1r5dsa8lbv7-source/nixos/doc/manual/release-notes/rl-1909.section.md
+++ b/deps/dep-rksi78f7vq2xrfghg6jfg1r5dsa8lbv7-source/nixos/doc/manual/release-notes/rl-1909.section.md
@@ -230,7 +230,7 @@ When upgrading from a previous release, please be aware of the following incompa
 
 - The `documentation` module gained an option named `documentation.nixos.includeAllModules` which makes the generated configuration.nix 5 manual page include all options from all NixOS modules included in a given `configuration.nix` configuration file. Currently, it is set to `false` by default as enabling it frequently prevents evaluation. But the plan is to eventually have it set to `true` by default. Please set it to `true` now in your `configuration.nix` and fix all the bugs it uncovers.
 
-- The `vlc` package gained support for Chromecast streaming, enabled by default. TCP port 8010 must be open for it to work, so something like `networking.firewall.allowedTCPPorts = [ 8010 ];` may be required in your configuration. Also consider enabling [ Accelerated Video Playback](https://nixos.wiki/wiki/Accelerated_Video_Playback) for better transcoding performance.
+- The `vlc` package gained support for Chromecast streaming, enabled by default. TCP port 8010 must be open for it to work, so something like `networking.firewall.allowedTCPPorts = [ 8010 ];` may be required in your configuration. Also consider enabling [ Accelerated Video Playback](https://wiki.nixos.org/wiki/Accelerated_Video_Playback) for better transcoding performance.
 
 - The following changes apply if the `stateVersion` is changed to 19.09 or higher. For `stateVersion = "19.03"` or lower the old behavior is preserved.
 

--- a/deps/dep-rksi78f7vq2xrfghg6jfg1r5dsa8lbv7-source/pkgs/development/tools/build-managers/ekam/default.nix
+++ b/deps/dep-rksi78f7vq2xrfghg6jfg1r5dsa8lbv7-source/pkgs/development/tools/build-managers/ekam/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation {
   # of the nix store -- but ekam builds capnp locally and links against it,
   # so that causes the build to fail. So, we turn this off.
   #
-  # See: https://nixos.wiki/wiki/Development_environment_with_nix-shell#Troubleshooting
+  # See: https://wiki.nixos.org/wiki/Development_environment_with_nix-shell#Troubleshooting
   preBuild = ''
     unset NIX_ENFORCE_PURITY
   '';

--- a/deps/dep-rksi78f7vq2xrfghg6jfg1r5dsa8lbv7-source/pkgs/tools/misc/polar/default.nix
+++ b/deps/dep-rksi78f7vq2xrfghg6jfg1r5dsa8lbv7-source/pkgs/tools/misc/polar/default.nix
@@ -33,7 +33,7 @@ stdenv.mkDerivation rec {
   '';
   buildInputs = [ gems ruby ];
 
-  # See: https://nixos.wiki/wiki/Packaging/Ruby
+  # See: https://wiki.nixos.org/wiki/Packaging/Ruby
   #
   # Put library content under lib/polar and the raw scripts under share/polar.
   # Then, wrap the scripts so that they use the correct ruby environment and put

--- a/deps/dep-wci7hc8223qwa18v6di0bahszb7sql7z-source/README.md
+++ b/deps/dep-wci7hc8223qwa18v6di0bahszb7sql7z-source/README.md
@@ -7,7 +7,7 @@
 A compatible but better replacement for rust overlay of [nixpkgs-mozilla].
 
 Hashes of toolchain components are pre-fetched in tree, so the evaluation is *pure* and
-no need to have network access. It also works well with [Nix Flakes](https://nixos.wiki/wiki/Flakes).
+no need to have network access. It also works well with [Nix Flakes](https://wiki.nixos.org/wiki/Flakes).
 
 - The toolchain hashes are auto-updated daily using GitHub Actions.
 - Current oldest supported version is stable 1.29.0 and beta/nightly 2018-09-13

--- a/deps/dep-wci7hc8223qwa18v6di0bahszb7sql7z-source/docs/cross_compilation.md
+++ b/deps/dep-wci7hc8223qwa18v6di0bahszb7sql7z-source/docs/cross_compilation.md
@@ -57,4 +57,4 @@ mkShell {
 ```
 
 For more details about these different kinds of dependencies,
-see also [Nix Wiki - Cross Compiling](https://nixos.wiki/wiki/Cross_Compiling#How_to_specify_dependencies).
+see also [Nix Wiki - Cross Compiling](https://wiki.nixos.org/wiki/Cross_Compiling#How_to_specify_dependencies).

--- a/deps/dep-yg7sklj8a9lj3gzjygcdigvqvxnasrmw-source/README.md
+++ b/deps/dep-yg7sklj8a9lj3gzjygcdigvqvxnasrmw-source/README.md
@@ -205,7 +205,7 @@ You can run the CLI tool ad-hoc without installing it:
 nix run github:ryantm/agenix -- --help
 ```
 
-But you can also add it permanently into a [NixOS module](https://nixos.wiki/wiki/NixOS_modules) 
+But you can also add it permanently into a [NixOS module](https://wiki.nixos.org/wiki/NixOS_modules) 
 (replace system "x86_64-linux" with your system):
 
 ```nix
@@ -304,7 +304,7 @@ e.g. inside your `flake.nix` file:
    ```
    You can reference the mount path to the (later) unencrypted secret already in your other configuration.
    So `config.age.secrets.secret1.path` will contain the path `/run/agenix/secret1` by default.
-7. Use `nixos-rebuild` or [another deployment tool](https://nixos.wiki/wiki/Applications#Deployment") of choice as usual.
+7. Use `nixos-rebuild` or [another deployment tool](https://wiki.nixos.org/wiki/Applications#Deployment") of choice as usual.
 
    The `secret1.age` file will be copied over to the target machine like any other Nix package. 
    Then it will be decrypted and mounted as described before.


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️